### PR TITLE
feat: cleanup API by unexporting internal ReportLog type

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -100,7 +100,7 @@ func (a *Agent) RoundTrip(req *http.Request) (*http.Response, error) {
 					// FIXME: log an internal error
 				}
 			}()
-			if err := a.logRecords([]ReportLog{record}); err != nil {
+			if err := a.logRecords([]reportLog{record}); err != nil {
 				a.logger().Warn("log record", zap.Error(err))
 			}
 		}()
@@ -116,8 +116,8 @@ func (a *Agent) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, roundtripError
 }
 
-func newRecord(req *http.Request, resp *http.Response, start, end time.Time, reqReader io.ReadCloser, logger *zap.Logger, roundtripError error) ReportLog {
-	record := ReportLog{
+func newRecord(req *http.Request, resp *http.Response, start, end time.Time, reqReader io.ReadCloser, logger *zap.Logger, roundtripError error) reportLog {
+	record := reportLog{
 		Protocol:        req.URL.Scheme,
 		Path:            req.URL.Path,
 		Hostname:        req.URL.Hostname(),
@@ -242,7 +242,7 @@ func (a *Agent) config() *Config {
 	return a.configCache
 }
 
-func (a Agent) logRecords(records []ReportLog) error {
+func (a Agent) logRecords(records []reportLog) error {
 	if len(records) < 1 {
 		return nil
 	}
@@ -259,7 +259,7 @@ func (a Agent) logRecords(records []ReportLog) error {
 			LogLevel string `json:"log_level"`
 			// FIXME: Config
 		} `json:"agent"`
-		Logs []ReportLog `json:"logs"`
+		Logs []reportLog `json:"logs"`
 	}
 	input := logsRequest{SecretKey: a.SecretKey, Logs: records}
 	input.Runtime.Type = "go"

--- a/agent_test.go
+++ b/agent_test.go
@@ -58,7 +58,7 @@ func TestAgent_config(t *testing.T) {
 }
 
 func TestAgent_logRecords(t *testing.T) {
-	records := []ReportLog{
+	records := []reportLog{
 		{
 			Protocol:        "https",
 			Path:            "/sample",

--- a/sanitize.go
+++ b/sanitize.go
@@ -20,7 +20,7 @@ var (
 )
 
 // sanitize prevents most of the credentials from being sent to Bearer
-func (r *ReportLog) sanitize() error {
+func (r *reportLog) sanitize() error {
 	// sanitize headers
 	if r.RequestHeaders != nil {
 		for k, v := range r.RequestHeaders {

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSanitize(t *testing.T) {
-	saneReport := ReportLog{
+	saneReport := reportLog{
 		Protocol:        "https",
 		Path:            "/sample",
 		Hostname:        "api.example.com",
@@ -29,49 +29,49 @@ func TestSanitize(t *testing.T) {
 	}
 
 	var tests = []struct {
-		input          ReportLog
-		expectedOutput ReportLog
+		input          reportLog
+		expectedOutput reportLog
 		expectedErr    error
 	}{
 		{saneReport, saneReport, nil},
-		{ReportLog{RequestHeaders: map[string]string{"authorization": "hello"}}, ReportLog{RequestHeaders: map[string]string{"authorization": "[FILTERED]"}}, nil},
-		{ReportLog{RequestHeaders: map[string]string{"Authorization": "hello"}}, ReportLog{RequestHeaders: map[string]string{"Authorization": "[FILTERED]"}}, nil},
-		{ReportLog{RequestHeaders: map[string]string{"AutHorizAtion": "hello"}}, ReportLog{RequestHeaders: map[string]string{"AutHorizAtion": "[FILTERED]"}}, nil},
-		{ReportLog{RequestHeaders: map[string]string{"Authorization2": "hello"}}, ReportLog{RequestHeaders: map[string]string{"Authorization2": "hello"}}, nil},
-		{ReportLog{RequestHeaders: map[string]string{"2Authorization": "hello"}}, ReportLog{RequestHeaders: map[string]string{"2Authorization": "hello"}}, nil},
-		{ReportLog{RequestHeaders: map[string]string{"Blah": "hello"}}, ReportLog{RequestHeaders: map[string]string{"Blah": "hello"}}, nil},
-		{ReportLog{RequestHeaders: map[string]string{"Blah": "contact@example.com"}}, ReportLog{RequestHeaders: map[string]string{"Blah": "[FILTERED].com"}}, nil},
-		{ReportLog{RequestHeaders: map[string]string{"Blah": "aaa bbb@ccc ddd eee@fff.ggg hhh"}}, ReportLog{RequestHeaders: map[string]string{"Blah": "aaa [FILTERED] ddd [FILTERED].ggg hhh"}}, nil},
-		{ReportLog{ResponseHeaders: map[string]string{"authorization": "hello"}}, ReportLog{ResponseHeaders: map[string]string{"authorization": "[FILTERED]"}}, nil},
-		{ReportLog{ResponseHeaders: map[string]string{"Authorization": "hello"}}, ReportLog{ResponseHeaders: map[string]string{"Authorization": "[FILTERED]"}}, nil},
-		{ReportLog{ResponseHeaders: map[string]string{"AutHorizAtion": "hello"}}, ReportLog{ResponseHeaders: map[string]string{"AutHorizAtion": "[FILTERED]"}}, nil},
-		{ReportLog{ResponseHeaders: map[string]string{"Authorization2": "hello"}}, ReportLog{ResponseHeaders: map[string]string{"Authorization2": "hello"}}, nil},
-		{ReportLog{ResponseHeaders: map[string]string{"2Authorization": "hello"}}, ReportLog{ResponseHeaders: map[string]string{"2Authorization": "hello"}}, nil},
-		{ReportLog{ResponseHeaders: map[string]string{"Blah": "hello"}}, ReportLog{ResponseHeaders: map[string]string{"Blah": "hello"}}, nil},
-		{ReportLog{ResponseHeaders: map[string]string{"Blah": "contact@example.com"}}, ReportLog{ResponseHeaders: map[string]string{"Blah": "[FILTERED].com"}}, nil},
-		{ReportLog{ResponseHeaders: map[string]string{"Blah": "aaa bbb@ccc ddd eee@fff.ggg hhh"}}, ReportLog{ResponseHeaders: map[string]string{"Blah": "aaa [FILTERED] ddd [FILTERED].ggg hhh"}}, nil},
-		{ReportLog{URL: "http://api.example.com/blah/blih?bluh=bloh&blouh=blanh"}, ReportLog{URL: "http://api.example.com/blah/blih?bluh=bloh&blouh=blanh"}, nil},
-		{ReportLog{URL: "http://api.example.com/blah/blih?bluh=Authorization&authorization=blanh"}, ReportLog{URL: ""}, nil},
-		{ReportLog{URL: "http://api.example.com/email/contact@example.org"}, ReportLog{URL: "http://api.example.com/email/[FILTERED].org"}, nil},
-		{ReportLog{RequestHeaders: map[string]string{"Content-Type": "application/json"}, RequestBody: `{"authorization":"blah"}`}, ReportLog{RequestHeaders: map[string]string{"Content-Type": "application/json"}, RequestBody: `{"authorization":"[FILTERED]"}`}, nil},
-		{ReportLog{RequestHeaders: map[string]string{"Content-Type": "application/json; charset=utf-8"}, RequestBody: `{"authorization":"blah"}`}, ReportLog{RequestHeaders: map[string]string{"Content-Type": "application/json; charset=utf-8"}, RequestBody: `{"authorization":"[FILTERED]"}`}, nil},
-		{ReportLog{RequestHeaders: map[string]string{"Content-Type": "application/json"}, RequestBody: `[42]`}, ReportLog{RequestHeaders: map[string]string{"Content-Type": "application/json"}, RequestBody: `[42]`}, nil},
-		{ReportLog{RequestHeaders: map[string]string{"Content-Type": "application/json"}, RequestBody: `42`}, ReportLog{RequestHeaders: map[string]string{"Content-Type": "application/json"}, RequestBody: `42`}, nil},
-		{ReportLog{RequestHeaders: map[string]string{"Content-Type": "application/json"}, RequestBody: `{}`}, ReportLog{RequestHeaders: map[string]string{"Content-Type": "application/json"}, RequestBody: `{}`}, nil},
-		// FIXME: {ReportLog{RequestHeaders: map[string]string{"Content-Type": "application/json"}, RequestBody: `{"a":{"authorization":"blah"}}`}, ReportLog{RequestHeaders: map[string]string{"Content-Type": "application/json"}, RequestBody: `{"a":{"authorization}:"[FILTERED]"}`}, nil},
+		{reportLog{RequestHeaders: map[string]string{"authorization": "hello"}}, reportLog{RequestHeaders: map[string]string{"authorization": "[FILTERED]"}}, nil},
+		{reportLog{RequestHeaders: map[string]string{"Authorization": "hello"}}, reportLog{RequestHeaders: map[string]string{"Authorization": "[FILTERED]"}}, nil},
+		{reportLog{RequestHeaders: map[string]string{"AutHorizAtion": "hello"}}, reportLog{RequestHeaders: map[string]string{"AutHorizAtion": "[FILTERED]"}}, nil},
+		{reportLog{RequestHeaders: map[string]string{"Authorization2": "hello"}}, reportLog{RequestHeaders: map[string]string{"Authorization2": "hello"}}, nil},
+		{reportLog{RequestHeaders: map[string]string{"2Authorization": "hello"}}, reportLog{RequestHeaders: map[string]string{"2Authorization": "hello"}}, nil},
+		{reportLog{RequestHeaders: map[string]string{"Blah": "hello"}}, reportLog{RequestHeaders: map[string]string{"Blah": "hello"}}, nil},
+		{reportLog{RequestHeaders: map[string]string{"Blah": "contact@example.com"}}, reportLog{RequestHeaders: map[string]string{"Blah": "[FILTERED].com"}}, nil},
+		{reportLog{RequestHeaders: map[string]string{"Blah": "aaa bbb@ccc ddd eee@fff.ggg hhh"}}, reportLog{RequestHeaders: map[string]string{"Blah": "aaa [FILTERED] ddd [FILTERED].ggg hhh"}}, nil},
+		{reportLog{ResponseHeaders: map[string]string{"authorization": "hello"}}, reportLog{ResponseHeaders: map[string]string{"authorization": "[FILTERED]"}}, nil},
+		{reportLog{ResponseHeaders: map[string]string{"Authorization": "hello"}}, reportLog{ResponseHeaders: map[string]string{"Authorization": "[FILTERED]"}}, nil},
+		{reportLog{ResponseHeaders: map[string]string{"AutHorizAtion": "hello"}}, reportLog{ResponseHeaders: map[string]string{"AutHorizAtion": "[FILTERED]"}}, nil},
+		{reportLog{ResponseHeaders: map[string]string{"Authorization2": "hello"}}, reportLog{ResponseHeaders: map[string]string{"Authorization2": "hello"}}, nil},
+		{reportLog{ResponseHeaders: map[string]string{"2Authorization": "hello"}}, reportLog{ResponseHeaders: map[string]string{"2Authorization": "hello"}}, nil},
+		{reportLog{ResponseHeaders: map[string]string{"Blah": "hello"}}, reportLog{ResponseHeaders: map[string]string{"Blah": "hello"}}, nil},
+		{reportLog{ResponseHeaders: map[string]string{"Blah": "contact@example.com"}}, reportLog{ResponseHeaders: map[string]string{"Blah": "[FILTERED].com"}}, nil},
+		{reportLog{ResponseHeaders: map[string]string{"Blah": "aaa bbb@ccc ddd eee@fff.ggg hhh"}}, reportLog{ResponseHeaders: map[string]string{"Blah": "aaa [FILTERED] ddd [FILTERED].ggg hhh"}}, nil},
+		{reportLog{URL: "http://api.example.com/blah/blih?bluh=bloh&blouh=blanh"}, reportLog{URL: "http://api.example.com/blah/blih?bluh=bloh&blouh=blanh"}, nil},
+		{reportLog{URL: "http://api.example.com/blah/blih?bluh=Authorization&authorization=blanh"}, reportLog{URL: ""}, nil},
+		{reportLog{URL: "http://api.example.com/email/contact@example.org"}, reportLog{URL: "http://api.example.com/email/[FILTERED].org"}, nil},
+		{reportLog{RequestHeaders: map[string]string{"Content-Type": "application/json"}, RequestBody: `{"authorization":"blah"}`}, reportLog{RequestHeaders: map[string]string{"Content-Type": "application/json"}, RequestBody: `{"authorization":"[FILTERED]"}`}, nil},
+		{reportLog{RequestHeaders: map[string]string{"Content-Type": "application/json; charset=utf-8"}, RequestBody: `{"authorization":"blah"}`}, reportLog{RequestHeaders: map[string]string{"Content-Type": "application/json; charset=utf-8"}, RequestBody: `{"authorization":"[FILTERED]"}`}, nil},
+		{reportLog{RequestHeaders: map[string]string{"Content-Type": "application/json"}, RequestBody: `[42]`}, reportLog{RequestHeaders: map[string]string{"Content-Type": "application/json"}, RequestBody: `[42]`}, nil},
+		{reportLog{RequestHeaders: map[string]string{"Content-Type": "application/json"}, RequestBody: `42`}, reportLog{RequestHeaders: map[string]string{"Content-Type": "application/json"}, RequestBody: `42`}, nil},
+		{reportLog{RequestHeaders: map[string]string{"Content-Type": "application/json"}, RequestBody: `{}`}, reportLog{RequestHeaders: map[string]string{"Content-Type": "application/json"}, RequestBody: `{}`}, nil},
+		// FIXME: {reportLog{RequestHeaders: map[string]string{"Content-Type": "application/json"}, RequestBody: `{"a":{"authorization":"blah"}}`}, reportLog{RequestHeaders: map[string]string{"Content-Type": "application/json"}, RequestBody: `{"a":{"authorization}:"[FILTERED]"}`}, nil},
 	}
 	i := 0
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			err := test.input.sanitize()
 			require.NoError(t, err)
-			checkSameReportLogs(t, test.expectedOutput, test.input)
+			checkSamereportLogs(t, test.expectedOutput, test.input)
 		})
 		i++
 	}
 }
 
-func checkSameReportLogs(t *testing.T, a, b ReportLog) {
+func checkSamereportLogs(t *testing.T, a, b reportLog) {
 	t.Helper()
 
 	assert.Equal(t, a.Protocol, b.Protocol)

--- a/types.go
+++ b/types.go
@@ -8,8 +8,8 @@ type Config struct {
 	// FIXME: add missing fieldss
 }
 
-// ReportLog is the log object sent to Bearer's API.
-type ReportLog struct {
+// reportLog is the log object sent to Bearer's API.
+type reportLog struct {
 	Protocol        string            `json:"protocol"`
 	Path            string            `json:"path"`
 	Hostname        string            `json:"hostname"`
@@ -27,7 +27,7 @@ type ReportLog struct {
 }
 
 // RequestContentType returns the value of the requesting "Content-Type" HTTP header.
-func (r ReportLog) RequestContentType() string {
+func (r reportLog) RequestContentType() string {
 	if r.RequestHeaders != nil {
 		for k, v := range r.RequestHeaders {
 			if strings.ToLower(k) == "content-type" {
@@ -39,7 +39,7 @@ func (r ReportLog) RequestContentType() string {
 }
 
 // ResponseContentType returns the value of the replying "Content-Type" HTTP header.
-func (r ReportLog) ResponseContentType() string {
+func (r reportLog) ResponseContentType() string {
 	if r.ResponseHeaders != nil {
 		for k, v := range r.ResponseHeaders {
 			if strings.ToLower(k) == "content-type" {


### PR DESCRIPTION
Generated doc on pkg.go.dev will be more focused